### PR TITLE
Fixed default usb_disk path and import of numbers with *

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -434,7 +434,7 @@ class CardDAV2FB
               {
                 $phone_number = $t['value'];
                 
-                $phone_number_clean = preg_replace("/[^0-9+]/", "", $phone_number);
+                $phone_number_clean = preg_replace("/[^0-9\*\#+]/", "", $phone_number);
                 foreach($quick_dial_arr as $qd_phone_nr => $value)
                 {
                   if($qd_phone_nr == $phone_number_clean)
@@ -517,7 +517,7 @@ class CardDAV2FB
 
   private function _clear_phone_number($number)
   {
-    return preg_replace("/[^0-9+]/", "", $number);
+    return preg_replace("/[^0-9\*\#+]/", "", $number);
   }
 
   public function build_fb_xml()
@@ -608,7 +608,7 @@ class CardDAV2FB
             }
 
             // add contact photo to xml
-            $person->addChild("imageURL", $this->config['fritzbox_path'] . $this->config['usb_disk'] . "FRITZ/fonpix/" . basename($photo_file));
+            $person->addChild("imageURL", $this->config['fritzbox_path'] . $this->config['usb_disk'] . "/FRITZ/fonpix/" . basename($photo_file));
 
             print "  Added photo: " . basename($photo_file) . PHP_EOL;
           }


### PR DESCRIPTION
changed FRITZ/fonpix/ to /FRITZ/fonpix/ (otherweise empty/default usbdisk path will not work)

modified phone number import filter to allow * and # as part of phone numbers (for example used for internal numbers "**610" in FritzBox)